### PR TITLE
Prevent updating go version in go.mod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
       "automerge": true,
       "groupName": "all non-major dependencies",
       "groupSlug": "all-non-major"
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Renovate should not update go version, since it indicates the minimum version supported