### PR TITLE
Update hook payload for webhook and SQS

### DIFF
--- a/functions/emailReceive/main.go
+++ b/functions/emailReceive/main.go
@@ -111,12 +111,13 @@ func receiveEmail(ctx context.Context, ses events.SimpleEmailService) {
 		log.Printf("failed to send email receipt to SQS, %v\n", err)
 	}
 
-	err = hook.SendWebhook(ctx, &hook.Webhook{
+	err = hook.SendWebhook(ctx, &hook.Hook{
 		Event:  hook.EventEmail,
 		Action: hook.ActionReceived,
 		Email: hook.Email{
 			ID: ses.Mail.MessageID,
 		},
+		Timestamp: ses.Mail.Timestamp.UTC().Format(time.RFC3339),
 	})
 	if err != nil {
 		log.Printf("failed to send webhook, %v\n", err)

--- a/internal/hook/content.go
+++ b/internal/hook/content.go
@@ -11,17 +11,11 @@ type EmailReceipt struct {
 	Timestamp string
 }
 
-// EmailNotification contains information needed for an email state change notification
-type EmailNotification struct {
+type Hook struct {
 	Event     string `json:"event"`
-	MessageID string `json:"messageID"`
+	Action    string `json:"action"`
 	Timestamp string `json:"timestamp"`
-}
-
-type Webhook struct {
-	Event  string `json:"event"`
-	Action string `json:"action"`
-	Email  Email
+	Email     Email
 }
 
 type Email struct {

--- a/internal/hook/webhook.go
+++ b/internal/hook/webhook.go
@@ -17,7 +17,7 @@ func webhookEnabled() bool {
 
 // SendWebhook sends a webhook to the configured URL, if webhook is enabled.
 // Otherwise, it does nothing.
-func SendWebhook(ctx context.Context, data *Webhook) error {
+func SendWebhook(ctx context.Context, data *Hook) error {
 	if !webhookEnabled() {
 		return nil
 	}

--- a/internal/hook/webhook_test.go
+++ b/internal/hook/webhook_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestSendWebhook(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		var webhook Webhook
+		var webhook Hook
 		err := json.NewDecoder(req.Body).Decode(&webhook)
 		assert.Nil(t, err)
 		assert.Equal(t, EventEmail, webhook.Event)
@@ -26,7 +26,7 @@ func TestSendWebhook(t *testing.T) {
 	defer server.Close()
 
 	env.WebhookURL = server.URL
-	err := SendWebhook(context.Background(), &Webhook{
+	err := SendWebhook(context.Background(), &Hook{
 		Event:  EventEmail,
 		Action: ActionReceived,
 		Email:  Email{ID: "123"},
@@ -36,7 +36,7 @@ func TestSendWebhook(t *testing.T) {
 
 func TestSendWebhook_NoOp(t *testing.T) {
 	env.WebhookURL = ""
-	err := SendWebhook(context.Background(), &Webhook{
+	err := SendWebhook(context.Background(), &Hook{
 		Event:  EventEmail,
 		Action: ActionReceived,
 		Email:  Email{ID: "123"},
@@ -46,7 +46,7 @@ func TestSendWebhook_NoOp(t *testing.T) {
 
 func TestSendWebhook_Error(t *testing.T) {
 	env.WebhookURL = "invalid-url"
-	err := SendWebhook(context.Background(), &Webhook{
+	err := SendWebhook(context.Background(), &Hook{
 		Event:  EventEmail,
 		Action: ActionReceived,
 		Email:  Email{ID: "123"},


### PR DESCRIPTION
Change their payload so that the data structure they use are the same. It's now:

```json
{
  "event": "email",
  "action": "received",
  "timestamp": "timestamp-in-RFC3339",
  "email": {
    "id": "email-id"
  }
}
```