### PR TITLE
Fix new golangci lint error

### DIFF
--- a/internal/datasource/storage/s3.go
+++ b/internal/datasource/storage/s3.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -57,7 +58,10 @@ func (s s3Storage) GetEmail(ctx context.Context, api S3GetObjectAPI, messageID s
 	if err != nil {
 		return nil, err
 	}
-	defer object.Body.Close()
+	defer func() {
+		err = object.Body.Close()
+		fmt.Println("error closing object body", err)
+	}()
 
 	env, err := readEmailEnvelope(object.Body)
 	if err != nil {
@@ -81,7 +85,10 @@ func (s s3Storage) GetEmailRaw(ctx context.Context, api S3GetObjectAPI, messageI
 	if err != nil {
 		return nil, err
 	}
-	defer object.Body.Close()
+	defer func() {
+		err = object.Body.Close()
+		fmt.Println("error closing object body", err)
+	}()
 
 	raw, err := io.ReadAll(object.Body)
 	return raw, err
@@ -101,7 +108,10 @@ func (s s3Storage) GetEmailContent(ctx context.Context, api S3GetObjectAPI, mess
 	if err != nil {
 		return nil, err
 	}
-	defer object.Body.Close()
+	defer func() {
+		err = object.Body.Close()
+		fmt.Println("error closing object body", err)
+	}()
 
 	env, err := readEmailEnvelope(object.Body)
 	if err != nil {

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -103,7 +103,7 @@ type RawEmailItem struct {
 }
 
 func (raw RawEmailItem) ToEmailItem() (*Item, error) {
-	index, err := raw.GSIIndex.ToTimeIndex()
+	index, err := raw.ToTimeIndex()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/email/get.go
+++ b/internal/email/get.go
@@ -137,9 +137,10 @@ func ParseGetResult(attributeValues map[string]dynamodbTypes.AttributeValue) (*G
 			result.Unread = &unread
 		}
 	} else {
-		if result.Type == types.EmailTypeDraft {
+		switch result.Type {
+		case types.EmailTypeDraft:
 			result.TimeUpdated = emailTime
-		} else if result.Type == types.EmailTypeSent {
+		case types.EmailTypeSent:
 			result.TimeSent = emailTime
 		}
 		result.Unread = nil

--- a/internal/email/list_query.go
+++ b/internal/email/list_query.go
@@ -60,9 +60,10 @@ func listByYearMonth(ctx context.Context, client api.QueryAPI, input listQueryIn
 		Limit:            limit,
 		ScanIndexForward: aws.Bool(false), // reverse order
 	}
-	if input.showTrash == ShowTrashExclude {
+	switch input.showTrash {
+	case ShowTrashExclude:
 		queryInput.FilterExpression = aws.String("attribute_not_exists(TrashedTime)")
-	} else if input.showTrash == ShowTrashOnly {
+	case ShowTrashOnly:
 		queryInput.FilterExpression = aws.String("attribute_exists(TrashedTime)")
 	}
 

--- a/internal/hook/webhook.go
+++ b/internal/hook/webhook.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -40,7 +41,10 @@ func SendWebhook(ctx context.Context, data *Hook) error {
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		err = res.Body.Close()
+		fmt.Println("error closing object body", err)
+	}()
 
 	return nil
 }

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -356,8 +356,8 @@ func TestStoreEmailWithNewThread(t *testing.T) {
 						if item.Put != nil {
 							assert.Equal(t, env.TableName, *item.Put.TableName)
 
-							switch {
-							case item.Put.Item["MessageID"].(*dynamodbTypes.AttributeValueMemberS).Value == "exampleThreadID":
+							switch item.Put.Item["MessageID"].(*dynamodbTypes.AttributeValueMemberS).Value {
+							case "exampleThreadID":
 								assert.Equal(t, map[string]dynamodbTypes.AttributeValue{
 									"MessageID": &dynamodbTypes.AttributeValueMemberS{Value: "exampleThreadID"},
 									"TypeYearMonth": &dynamodbTypes.AttributeValueMemberS{
@@ -372,7 +372,7 @@ func TestStoreEmailWithNewThread(t *testing.T) {
 									"TimeUpdated": &dynamodbTypes.AttributeValueMemberS{Value: "2023-02-19T01:01:01Z"},
 									"Subject":     &dynamodbTypes.AttributeValueMemberS{Value: "exampleCreatingSubject"},
 								}, item.Put.Item)
-							case item.Put.Item["MessageID"].(*dynamodbTypes.AttributeValueMemberS).Value == "exampleMessageID":
+							case "exampleMessageID":
 								assert.Equal(t, map[string]dynamodbTypes.AttributeValue{
 									"MessageID":      &dynamodbTypes.AttributeValueMemberS{Value: "exampleMessageID"},
 									"IsThreadLatest": &dynamodbTypes.AttributeValueMemberBOOL{Value: true},

--- a/internal/util/format/extract.go
+++ b/internal/util/format/extract.go
@@ -26,11 +26,11 @@ func ExtractTypeYearMonth(s string) (emailType string, yearMonth string, err err
 		return "", "", ErrInvalidEmailType
 	}
 
-	if year, err := strconv.Atoi(yearMonthParts[0]); err != nil || !(year >= 1000) {
+	if year, err := strconv.Atoi(yearMonthParts[0]); err != nil || year < 1000 {
 		fmt.Printf("ExtractTypeYearMonth(%s) fail: year must be 4 digit integer\n", s)
 		return "", "", ErrInvalidEmailYear
 	}
-	if month, err := strconv.Atoi(yearMonthParts[1]); err != nil || !(month >= 1 && month <= 12) {
+	if month, err := strconv.Atoi(yearMonthParts[1]); err != nil || month < 1 || month > 12 {
 		fmt.Printf("ExtractTypeYearMonth(%s) failed: month must be between 1 and 12\n", s)
 		return "", "", ErrInvalidEmailMonth
 	}


### PR DESCRIPTION
- Always check returned error
- Skip embedded struct to access methods
- Prefer `switch` over `if`
- Fix `staticcheck` QF1001