### PR TITLE
Use GitHub OIDC for CI instead of a long-lived access key

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,6 +59,10 @@ jobs:
       TF_VAR_aws_dynamodb_table_override: ${{ secrets.TF_VAR_AWS_DYNAMODB_TABLE_OVERRIDE }}
       TF_VAR_ses_receipt_rule_set_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_SET_NAME }}
       TF_VAR_ses_receipt_rule_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_NAME }}
+    # id-token mints the OIDC token, scoped to this job
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -84,8 +88,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_PLAN_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Terraform Init

--- a/oidc.tf
+++ b/oidc.tf
@@ -1,0 +1,117 @@
+# GitHub Actions OIDC: CI assumes a short-lived role instead of holding a
+# long-lived access key. Opt-in - a fresh clone creates nothing.
+
+locals {
+  # The OIDC provider is account-global and shared with other projects, so it
+  # is created out of band and referenced by ARN.
+  oidc_enabled = var.github_repository != "" && var.github_oidc_provider_arn != ""
+}
+
+resource "aws_iam_role" "github_plan" {
+  count = local.oidc_enabled ? 1 : 0
+
+  name = "${local.project_name_env}-github-plan"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Principal = { Federated = var.github_oidc_provider_arn }
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          # push to main, and pull requests from branches on this repo
+          "token.actions.githubusercontent.com:sub" = [
+            "repo:${var.github_repository}:ref:refs/heads/main",
+            "repo:${var.github_repository}:pull_request",
+          ]
+        }
+      }
+    }]
+  })
+}
+
+# Read-only, except on the state bucket: native locking writes and deletes
+# a .tflock object, so a plan cannot run without S3 write there.
+resource "aws_iam_policy" "github_plan" {
+  count = local.oidc_enabled ? 1 : 0
+
+  name        = "${local.project_name_env}-github-plan-policy"
+  description = "Permissions for terraform plan from GitHub Actions"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      var.tf_state_bucket != "" ? [
+        {
+          Effect   = "Allow"
+          Action   = ["s3:ListBucket"]
+          Resource = "arn:aws:s3:::${var.tf_state_bucket}"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+          Resource = "arn:aws:s3:::${var.tf_state_bucket}/*"
+        },
+      ] : [],
+      [
+        {
+          Effect   = "Allow"
+          Action   = ["apigateway:GET"]
+          Resource = "arn:aws:apigateway:${var.aws_region}::/apis/*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "lambda:GetFunction",
+            "lambda:GetFunctionCodeSigningConfig",
+            "lambda:GetPolicy",
+            "lambda:ListTags",
+            "lambda:ListVersionsByFunction",
+          ]
+          Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${local.project_name_env}-*"
+        },
+        {
+          # generated name suffixes, so these cannot be scoped by ARN
+          Effect   = "Allow"
+          Action   = ["lambda:GetCodeSigningConfig", "signer:GetSigningProfile"]
+          Resource = "*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["iam:GetRole", "iam:ListRolePolicies", "iam:ListAttachedRolePolicies"]
+          Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.project_name_env}-*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["iam:GetPolicy", "iam:GetPolicyVersion"]
+          Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${local.project_name_env}-*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["logs:DescribeLogGroups", "logs:ListTagsForResource"]
+          Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["sqs:GetQueueAttributes", "sqs:ListQueueTags"]
+          Resource = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${local.aws_sqs_queue_name}"
+        },
+        {
+          # no resource-level permissions for this action
+          Effect   = "Allow"
+          Action   = ["ses:DescribeReceiptRule"]
+          Resource = "*"
+        },
+      ]
+    )
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_plan" {
+  count = local.oidc_enabled ? 1 : 0
+
+  role       = aws_iam_role.github_plan[0].name
+  policy_arn = aws_iam_policy.github_plan[0].arn
+}

--- a/oidc.tf
+++ b/oidc.tf
@@ -73,10 +73,14 @@ resource "aws_iam_policy" "github_plan" {
           Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${local.project_name_env}-*"
         },
         {
-          # generated name suffixes, so these cannot be scoped by ARN
           Effect   = "Allow"
-          Action   = ["lambda:GetCodeSigningConfig", "signer:GetSigningProfile"]
-          Resource = "*"
+          Action   = ["lambda:GetCodeSigningConfig", "lambda:ListTags"]
+          Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:code-signing-config:*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["signer:GetSigningProfile"]
+          Resource = "arn:aws:signer:${var.aws_region}:${data.aws_caller_identity.current.account_id}:/signing-profiles/*"
         },
         {
           Effect   = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,25 @@ variable "aws_dynamodb_table_override" {
   default     = ""
 }
 
+variable "github_repository" {
+  description = "owner/repo allowed to assume the CI role. Leave empty to create no OIDC resources."
+  type        = string
+  default     = ""
+}
+
+variable "github_oidc_provider_arn" {
+  description = "Existing account-global GitHub OIDC provider ARN. Required to enable the CI role."
+  type        = string
+  default     = ""
+}
+
+variable "tf_state_bucket" {
+  description = "State bucket name, so the CI role can be scoped to it"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 locals {
   project_name_env            = "${var.project_name}-${var.environment}"
   aws_dynamodb_table_name     = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"


### PR DESCRIPTION
CI authenticated with a static access key that anyone with write access could exfiltrate via a workflow edit. It now assumes a short-lived role via OIDC.

The role is plan-only, scoped to the API calls a plan actually makes. It needs S3 write on the state bucket because native locking creates and deletes a `.tflock` object.

The account-global OIDC provider is referenced by ARN, not managed here.

Needs the `AWS_PLAN_ROLE_ARN` secret before merge; keep the old keys until a run goes green.