### PR TITLE
Move settled linter suppressions to config files

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -4,3 +4,6 @@ skip-check:
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158
+  # CKV_AWS_173: env vars hold resource names only, already encrypted under the
+  # default aws/lambda key. Real secrets belong in Secrets Manager, not here.
+  - CKV_AWS_173

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,8 +1,9 @@
 # Super-linter reads this from LINTER_RULES_PATH (.github/linters).
 #
 skip-check:
-  # CKV_AWS_117: the functions only reach public AWS API endpoints, so a VPC
-  # would add NAT or endpoint cost and cold-start latency for no isolation gain.
+  # CKV_AWS_117: reaches DynamoDB, S3, SQS, SES and an optional outbound
+  # webhook, all public endpoints, with no inbound network surface. A VPC would
+  # need NAT or interface endpoints and add cold starts for no isolation gain.
   - CKV_AWS_117
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,6 +1,9 @@
 # Super-linter reads this from LINTER_RULES_PATH (.github/linters).
 #
 skip-check:
+  # CKV_AWS_117: the functions only reach public AWS API endpoints, so a VPC
+  # would add NAT or endpoint cost and cold-start latency for no isolation gain.
+  - CKV_AWS_117
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,7 @@
+# Super-linter reads this from LINTER_RULES_PATH (.github/linters).
+#
+# CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
+# A CMK adds auditing and revocation this project doesn't need, at a monthly
+# cost. Applies to every log group here, so it's set repo wide.
+skip-check:
+  - CKV_AWS_158

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,7 +1,6 @@
 # Super-linter reads this from LINTER_RULES_PATH (.github/linters).
 #
-# CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
-# A CMK adds auditing and revocation this project doesn't need, at a monthly
-# cost. Applies to every log group here, so it's set repo wide.
 skip-check:
+  # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
+  # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -15,3 +15,5 @@ skip-check:
   # CKV_AWS_173: env vars hold resource names only, already encrypted under the
   # default aws/lambda key. Real secrets belong in Secrets Manager, not here.
   - CKV_AWS_173
+  # CKV2_AWS_16: load doesn't vary enough to autoscale.
+  - CKV2_AWS_16

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -5,6 +5,10 @@ skip-check:
   # webhook, all public endpoints, with no inbound network surface. A VPC would
   # need NAT or interface endpoints and add cold starts for no isolation gain.
   - CKV_AWS_117
+  # CKV_AWS_119: the table is already encrypted at rest under an AWS owned key.
+  # A CMK adds per-request KMS charges on every read and write, for control
+  # this project doesn't need.
+  - CKV_AWS_119
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158

--- a/.github/linters/.trivyignore.yaml
+++ b/.github/linters/.trivyignore.yaml
@@ -4,3 +4,8 @@ misconfigurations:
     statement: >-
       Encrypted at rest under an AWS owned key. A CMK adds auditing and
       revocation this project doesn't need immediately.
+  # AVD-AWS-0025 is the same finding as checkov CKV_AWS_119; see .checkov.yaml.
+  - id: AVD-AWS-0025
+    statement: >-
+      Encrypted at rest under an AWS owned key. A CMK adds per-request KMS
+      charges on every read and write for control this project doesn't need.

--- a/.github/linters/.trivyignore.yaml
+++ b/.github/linters/.trivyignore.yaml
@@ -1,0 +1,6 @@
+# AVD-AWS-0017 is the same finding as checkov CKV_AWS_158; see .checkov.yaml.
+misconfigurations:
+  - id: AVD-AWS-0017
+    statement: >-
+      Encrypted at rest under an AWS owned key. A CMK adds auditing and
+      revocation this project doesn't need, at a monthly cost.

--- a/.github/linters/.trivyignore.yaml
+++ b/.github/linters/.trivyignore.yaml
@@ -1,6 +1,6 @@
-# AVD-AWS-0017 is the same finding as checkov CKV_AWS_158; see .checkov.yaml.
 misconfigurations:
+  # AVD-AWS-0017 is the same finding as checkov CKV_AWS_158; see .checkov.yaml.
   - id: AVD-AWS-0017
     statement: >-
       Encrypted at rest under an AWS owned key. A CMK adds auditing and
-      revocation this project doesn't need, at a monthly cost.
+      revocation this project doesn't need immediately.

--- a/.github/linters/trivy.yaml
+++ b/.github/linters/trivy.yaml
@@ -1,0 +1,5 @@
+# Trivy configuration. Super-linter reads this from LINTER_RULES_PATH
+# (.github/linters). Locally: trivy config --config .github/linters/trivy.yaml .
+#
+# Check IDs can't be disabled here, so suppressions live in the ignore file.
+ignorefile: .github/linters/.trivyignore.yaml

--- a/main.tf
+++ b/main.tf
@@ -263,10 +263,8 @@ resource "aws_lambda_permission" "apigw_invoke" {
 }
 
 #trivy:ignore:AWS-0024
-#trivy:ignore:AWS-0025
 resource "aws_dynamodb_table" "mailbox_table" {
   #checkov:skip=CKV_AWS_28
-  #checkov:skip=CKV_AWS_119
   #checkov:skip=CKV2_AWS_16
 
   # Only managed when no existing table is supplied

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,7 @@ resource "aws_apigatewayv2_api" "mailbox_api" {
   protocol_type = "HTTP"
 }
 
-#trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "mailbox_api_access_logs" {
-  #checkov:skip=CKV_AWS_158: encryption needed for log group
   name              = "/aws/apigateway/${var.project_name}-api-access-logs"
   retention_in_days = 365
 }
@@ -158,17 +156,13 @@ resource "aws_lambda_code_signing_config" "lambda_code_signing" {
   description = "Code signing configuration for ${local.project_name_env} Lambda functions"
 }
 
-#trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "function_logs" {
-  #checkov:skip=CKV_AWS_158: encryption needed for log group
   for_each          = tomap(local.lambda_functions)
   name              = "/aws/lambda/${local.project_name_env}-${each.key}"
   retention_in_days = 365
 }
 
-#trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "email_receive_logs" {
-  #checkov:skip=CKV_AWS_158: encryption needed for log group
   name              = "/aws/lambda/${local.project_name_env}-email_receive"
   retention_in_days = 365
 }

--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,6 @@ resource "aws_cloudwatch_log_group" "email_receive_logs" {
 }
 
 resource "aws_lambda_function" "email_receive" {
-  #checkov:skip=CKV_AWS_117: VPC access
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
   function_name                  = "${local.project_name_env}-email_receive"
   filename                       = "bin/email_receive.zip"
@@ -204,7 +203,6 @@ resource "aws_lambda_function" "email_receive" {
 
 resource "aws_lambda_function" "functions" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  #checkov:skip=CKV_AWS_117: VPC access
   for_each                       = tomap(local.lambda_functions)
   function_name                  = "${local.project_name_env}-${each.key}"
   filename                       = "bin/${each.value.function}.zip"

--- a/main.tf
+++ b/main.tf
@@ -262,9 +262,10 @@ resource "aws_lambda_permission" "apigw_invoke" {
   source_arn    = "${aws_apigatewayv2_api.mailbox_api.execution_arn}/*/${each.value.httpMethod}${each.value.arnPath}"
 }
 
-#trivy:ignore:AWS-0024
+# TODO: enable point-in-time recovery
+#trivy:ignore:AVD-AWS-0024
 resource "aws_dynamodb_table" "mailbox_table" {
-  #checkov:skip=CKV_AWS_28
+  #checkov:skip=CKV_AWS_28: TODO: enable point-in-time recovery
 
   # Only managed when no existing table is supplied
   count = var.aws_dynamodb_table_override == "" ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -265,7 +265,6 @@ resource "aws_lambda_permission" "apigw_invoke" {
 #trivy:ignore:AWS-0024
 resource "aws_dynamodb_table" "mailbox_table" {
   #checkov:skip=CKV_AWS_28
-  #checkov:skip=CKV2_AWS_16
 
   # Only managed when no existing table is supplied
   count = var.aws_dynamodb_table_override == "" ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,6 @@ resource "aws_cloudwatch_log_group" "email_receive_logs" {
 resource "aws_lambda_function" "email_receive" {
   #checkov:skip=CKV_AWS_117: VPC access
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  #checkov:skip=CKV_AWS_173: TODO: add environment variable encryption
   function_name                  = "${local.project_name_env}-email_receive"
   filename                       = "bin/email_receive.zip"
   handler                        = "bootstrap"
@@ -204,9 +203,8 @@ resource "aws_lambda_function" "email_receive" {
 }
 
 resource "aws_lambda_function" "functions" {
-  #checkov:skip=CKV_AWS_117: VPC access
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  #checkov:skip=CKV_AWS_173: TODO: add environment variable encryption
+  #checkov:skip=CKV_AWS_117: VPC access
   for_each                       = tomap(local.lambda_functions)
   function_name                  = "${local.project_name_env}-${each.key}"
   filename                       = "bin/${each.value.function}.zip"


### PR DESCRIPTION
Inline suppressions in `main.tf` carried placeholder reasons (`encryption needed for log group`, `TODO: add environment variable encryption`) or none at all, and were copy-pasted forward as resources were added.

Settled decisions now live in config with a real reason; open work stays inline.

## Moved to config

| Check | Finding | Reason |
| --- | --- | --- |
| `CKV_AWS_117` | Lambda not in a VPC | Only public endpoints, no inbound network surface. A VPC needs NAT or interface endpoints for no isolation gain. |
| `CKV_AWS_119` / `AVD-AWS-0025` | DynamoDB not CMK-encrypted | Already encrypted under an AWS owned key; a CMK also bills per read and write. |
| `CKV_AWS_158` / `AVD-AWS-0017` | Log groups not CMK-encrypted | Already encrypted with AES-256-GCM under an AWS owned key. |
| `CKV_AWS_173` | Lambda env vars not CMK-encrypted | Always encrypted under the free `aws/lambda` key; these hold a region and resource names. |
| `CKV2_AWS_16` | DynamoDB auto scaling | Load doesn't vary enough to autoscale. |

All three encryption checks want a customer managed key. AWS already encrypts at rest in each case, so a CMK only adds auditing and revocation, at a standing monthly cost.

## Still inline

- `CKV_AWS_116` (dead letter queue) — a real gap on `email_receive`, which SES invokes asynchronously, but inapplicable to the 21 synchronous handlers. One config skip would silence both. Tracked in #864.
- `CKV_AWS_28` / `AVD-AWS-0024` (point-in-time recovery) — deferred, now marked `TODO:` rather than bare.

## Also

`AWS-0024` and `AWS-0025` were missing the `AVD-` prefix, so they matched nothing and both findings were reported regardless. 0024 is corrected; 0025 moved to the ignore file.

Trivy can't disable check IDs in its config, so `trivy.yaml` points at `.trivyignore.yaml` via `ignorefile`.

Neither scanner reaches `.tf` files in CI today: super-linter sets `FILTER_REGEX_INCLUDE: ".*go.mod"`, and its trivy validator skips Terraform. Correct but inert until that changes.