### PR TITLE
Enable DynamoDB point-in-time recovery by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ that each turn a feature on. Set them as `TF_VAR_` environment variables.
 | `project_name`, `environment` | Name resources. Default to `mailbox-v2` and `dev`. |
 | `aws_s3_bucket_override` | Use an existing email bucket instead of `<project>-<env>`. |
 | `aws_dynamodb_table_override` | Use an existing table instead of creating one. |
+| `aws_dynamodb_point_in_time_recovery` | Continuous backups on the managed table. Defaults to `true`; incurs [additional cost](https://aws.amazon.com/dynamodb/pricing/). |
 | `ses_receipt_rule_set_name`, `ses_receipt_rule_name` | Manage an existing SES receipt rule. Both required to enable; otherwise SES is left alone. |
 | `github_repository`, `github_oidc_provider_arn` | Create a CI role for that repo. Both required to enable. |
 

--- a/main.tf
+++ b/main.tf
@@ -262,11 +262,7 @@ resource "aws_lambda_permission" "apigw_invoke" {
   source_arn    = "${aws_apigatewayv2_api.mailbox_api.execution_arn}/*/${each.value.httpMethod}${each.value.arnPath}"
 }
 
-# TODO: enable point-in-time recovery
-#trivy:ignore:AVD-AWS-0024
 resource "aws_dynamodb_table" "mailbox_table" {
-  #checkov:skip=CKV_AWS_28: TODO: enable point-in-time recovery
-
   # Only managed when no existing table is supplied
   count = var.aws_dynamodb_table_override == "" ? 1 : 0
 
@@ -325,6 +321,10 @@ resource "aws_dynamodb_table" "mailbox_table" {
     projection_type = "KEYS_ONLY"
     read_capacity   = 3
     write_capacity  = 1
+  }
+
+  point_in_time_recovery {
+    enabled = var.aws_dynamodb_point_in_time_recovery
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "aws_dynamodb_table_override" {
   default     = ""
 }
 
+variable "aws_dynamodb_point_in_time_recovery" {
+  description = "Continuous backups on the managed DynamoDB table. Incurs additional cost."
+  type        = bool
+  default     = true
+}
+
 variable "github_repository" {
   description = "owner/repo allowed to assume the CI role. Leave empty to create no OIDC resources."
   type        = string


### PR DESCRIPTION
The table had no continuous backups, while the Lambda role holds `DeleteItem` and `BatchWriteItem` and `emails_delete`/`threads_delete` are wired to live HTTP routes — an accidental or buggy delete was unrecoverable.

Exposed as `aws_dynamodb_point_in_time_recovery` rather than hardcoded, so anyone deploying this repo can opt out of the cost. Defaults to `true`.