### PR TITLE
Enable code signing for Lambda functions

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,6 +1,10 @@
 # Super-linter reads this from LINTER_RULES_PATH (.github/linters).
 #
 skip-check:
+  # CKV_AWS_18: the artifacts bucket holds build output that is already
+  # published as a GitHub release asset, so there is nothing in it an access log
+  # would protect, and logging would need a second bucket to receive it.
+  - CKV_AWS_18
   # CKV_AWS_117: reaches DynamoDB, S3, SQS, SES and an optional outbound
   # webhook, all public endpoints, with no inbound network surface. A VPC would
   # need NAT or interface endpoints and add cold starts for no isolation gain.
@@ -9,6 +13,14 @@ skip-check:
   # A CMK adds per-request KMS charges on every read and write, for control
   # this project doesn't need.
   - CKV_AWS_119
+  # CKV_AWS_144: artifacts are rebuildable from a release, so losing a region
+  # means redeploying, not restoring. Replication would double storage to
+  # protect nothing that isn't already in git.
+  - CKV_AWS_144
+  # CKV_AWS_145: SSE-S3 is deliberate. AWS Signer reads the source object on the
+  # caller's behalf, so a CMK would need a grant for it, in return for control
+  # over artifacts that are public code anyway.
+  - CKV_AWS_145
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158
@@ -17,3 +29,6 @@ skip-check:
   - CKV_AWS_173
   # CKV2_AWS_16: load doesn't vary enough to autoscale.
   - CKV2_AWS_16
+  # CKV2_AWS_62: nothing consumes bucket events. Terraform drives the whole
+  # upload, sign and deploy sequence itself.
+  - CKV2_AWS_62

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,10 +1,6 @@
 # Super-linter reads this from LINTER_RULES_PATH (.github/linters).
 #
 skip-check:
-  # CKV_AWS_18: the artifacts bucket holds build output that is already
-  # published as a GitHub release asset, so there is nothing in it an access log
-  # would protect, and logging would need a second bucket to receive it.
-  - CKV_AWS_18
   # CKV_AWS_117: reaches DynamoDB, S3, SQS, SES and an optional outbound
   # webhook, all public endpoints, with no inbound network surface. A VPC would
   # need NAT or interface endpoints and add cold starts for no isolation gain.
@@ -13,14 +9,6 @@ skip-check:
   # A CMK adds per-request KMS charges on every read and write, for control
   # this project doesn't need.
   - CKV_AWS_119
-  # CKV_AWS_144: artifacts are rebuildable from a release, so losing a region
-  # means redeploying, not restoring. Replication would double storage to
-  # protect nothing that isn't already in git.
-  - CKV_AWS_144
-  # CKV_AWS_145: SSE-S3 is deliberate. AWS Signer reads the source object on the
-  # caller's behalf, so a CMK would need a grant for it, in return for control
-  # over artifacts that are public code anyway.
-  - CKV_AWS_145
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158
@@ -29,6 +17,3 @@ skip-check:
   - CKV_AWS_173
   # CKV2_AWS_16: load doesn't vary enough to autoscale.
   - CKV2_AWS_16
-  # CKV2_AWS_62: nothing consumes bucket events. Terraform drives the whole
-  # upload, sign and deploy sequence itself.
-  - CKV2_AWS_62

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -9,6 +9,8 @@ skip-check:
   # A CMK adds per-request KMS charges on every read and write, for control
   # this project doesn't need.
   - CKV_AWS_119
+  # CKV_AWS_145: objects are already encrypted at rest under SSE-S3.
+  - CKV_AWS_145
   # CKV_AWS_158: log data is already encrypted at rest under an AWS owned key.
   # A CMK adds auditing and revocation this project doesn't need now.
   - CKV_AWS_158

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,7 +56,7 @@ jobs:
       # Account-based DynamoDB endpoints leak the account ID via DNS
       AWS_ACCOUNT_ID_ENDPOINT_MODE: disabled
       TF_VAR_aws_s3_bucket_override: ${{ secrets.TF_VAR_AWS_S3_BUCKET_OVERRIDE }}
-      TF_VAR_aws_s3_artifacts_bucket_override: ${{ secrets.TF_VAR_AWS_S3_ARTIFACTS_BUCKET_OVERRIDE }}
+      TF_VAR_aws_s3_artifacts_bucket: ${{ secrets.TF_VAR_AWS_S3_ARTIFACTS_BUCKET }}
       TF_VAR_aws_dynamodb_table_override: ${{ secrets.TF_VAR_AWS_DYNAMODB_TABLE_OVERRIDE }}
       TF_VAR_ses_receipt_rule_set_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_SET_NAME }}
       TF_VAR_ses_receipt_rule_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_NAME }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,6 +56,7 @@ jobs:
       # Account-based DynamoDB endpoints leak the account ID via DNS
       AWS_ACCOUNT_ID_ENDPOINT_MODE: disabled
       TF_VAR_aws_s3_bucket_override: ${{ secrets.TF_VAR_AWS_S3_BUCKET_OVERRIDE }}
+      TF_VAR_aws_s3_artifacts_bucket_override: ${{ secrets.TF_VAR_AWS_S3_ARTIFACTS_BUCKET_OVERRIDE }}
       TF_VAR_aws_dynamodb_table_override: ${{ secrets.TF_VAR_AWS_DYNAMODB_TABLE_OVERRIDE }}
       TF_VAR_ses_receipt_rule_set_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_SET_NAME }}
       TF_VAR_ses_receipt_rule_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_NAME }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,7 +56,7 @@ jobs:
       # Account-based DynamoDB endpoints leak the account ID via DNS
       AWS_ACCOUNT_ID_ENDPOINT_MODE: disabled
       TF_VAR_aws_s3_bucket_override: ${{ secrets.TF_VAR_AWS_S3_BUCKET_OVERRIDE }}
-      TF_VAR_aws_s3_artifacts_bucket: ${{ secrets.TF_VAR_AWS_S3_ARTIFACTS_BUCKET }}
+      TF_VAR_aws_s3_artifacts_bucket_override: ${{ secrets.TF_VAR_AWS_S3_ARTIFACTS_BUCKET_OVERRIDE }}
       TF_VAR_aws_dynamodb_table_override: ${{ secrets.TF_VAR_AWS_DYNAMODB_TABLE_OVERRIDE }}
       TF_VAR_ses_receipt_rule_set_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_SET_NAME }}
       TF_VAR_ses_receipt_rule_name: ${{ secrets.TF_VAR_SES_RECEIPT_RULE_NAME }}

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ The provider sets only a region, so Terraform uses the standard AWS credential
 chain: environment variables, a named profile, or IAM Identity Center.
 
 Deploying needs write access to IAM, Lambda, API Gateway, CloudWatch Logs, SQS,
-Signer, SES, the state bucket, and — unless `aws_dynamodb_table_override` is set
-— DynamoDB. Creating the artifacts bucket also needs `s3:CreateBucket` and the
+Signer, SES, the state and artifact buckets, and — unless
+`aws_dynamodb_table_override` is set — DynamoDB. Signing packages needs
+`signer:StartSigningJob` and read and write on the artifacts bucket. Creating the artifacts bucket also needs `s3:CreateBucket` and the
 `s3:Get*`/`s3:Put*` bucket-configuration actions behind versioning, encryption,
 public access block, ownership controls, policy and lifecycle. One more is easy
 to miss: `iam:PassRole` for the Lambda execution role, because the resulting

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Two S3 buckets are created outside Terraform, because one must exist before
   be rolled back.
 - **An email bucket**, where SES delivers raw messages.
 
-A third bucket, for build artifacts, is created by Terraform and needs no setup.
-Lambda deployment packages are uploaded there to be signed, and its contents are
-rebuildable from a release.
+A third bucket, for build artifacts, is created by Terraform, but you have to
+name it through `aws_s3_artifacts_bucket`: bucket names are global, so no
+default reliably works. Lambda deployment packages are uploaded there to be
+signed, and its contents are rebuildable from a release.
 
 ### Credentials
 
@@ -79,15 +80,16 @@ GitHub OIDC; see `oidc.tf`.
 
 ### Configure
 
-Everything has a working default; the variables below are optional overrides
-that each turn a feature on. Set them as `TF_VAR_` environment variables.
+Only `aws_s3_artifacts_bucket` is required; everything else has a working
+default, and the rest of the variables below are optional overrides that each
+turn a feature on. Set them as `TF_VAR_` environment variables.
 
 | Variable | Purpose |
 | --- | --- |
+| `aws_s3_artifacts_bucket` | **Required.** Names the artifacts bucket Terraform creates for code signing. |
 | `aws_region` | Region to deploy into. Defaults to `us-west-2`. |
 | `project_name`, `environment` | Name resources. Default to `mailbox-v2` and `dev`. |
 | `aws_s3_bucket_override` | Use an existing email bucket instead of `<project>-<env>`. |
-| `aws_s3_artifacts_bucket_override` | Use a different artifacts bucket name instead of `<project>-<env>-artifacts`. |
 | `aws_dynamodb_table_override` | Use an existing table instead of creating one. |
 | `aws_dynamodb_point_in_time_recovery` | Continuous backups on the managed table. Defaults to `true`; incurs [additional cost](https://aws.amazon.com/dynamodb/pricing/). |
 | `ses_receipt_rule_set_name`, `ses_receipt_rule_name` | Manage an existing SES receipt rule. Both required to enable; otherwise SES is left alone. |
@@ -97,6 +99,7 @@ that each turn a feature on. Set them as `TF_VAR_` environment variables.
 
 ```shell
 export TF_STATE_BUCKET=<your-state-bucket>
+export TF_VAR_aws_s3_artifacts_bucket=<your-artifacts-bucket>
 make init
 make deploy
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Two S3 buckets are created outside Terraform, because one must exist before
   be rolled back.
 - **An email bucket**, where SES delivers raw messages.
 
+A third bucket, for build artifacts, is created by Terraform and needs no setup.
+Lambda deployment packages are uploaded there to be signed, and its contents are
+rebuildable from a release.
+
 ### Credentials
 
 The provider sets only a region, so Terraform uses the standard AWS credential
@@ -46,8 +50,11 @@ chain: environment variables, a named profile, or IAM Identity Center.
 
 Deploying needs write access to IAM, Lambda, API Gateway, CloudWatch Logs, SQS,
 Signer, SES, the state bucket, and — unless `aws_dynamodb_table_override` is set
-— DynamoDB. It also needs `iam:PassRole` for the Lambda execution role, which is
-easy to miss because the resulting error names `CreateFunction` instead.
+— DynamoDB. Creating the artifacts bucket also needs `s3:CreateBucket` and the
+`s3:Get*`/`s3:Put*` bucket-configuration actions behind versioning, encryption,
+public access block, ownership controls, policy and lifecycle. One more is easy
+to miss: `iam:PassRole` for the Lambda execution role, because the resulting
+error names `CreateFunction` instead.
 
 Attach those permissions to a role and assume it, rather than granting them to a
 user directly:
@@ -80,6 +87,7 @@ that each turn a feature on. Set them as `TF_VAR_` environment variables.
 | `aws_region` | Region to deploy into. Defaults to `us-west-2`. |
 | `project_name`, `environment` | Name resources. Default to `mailbox-v2` and `dev`. |
 | `aws_s3_bucket_override` | Use an existing email bucket instead of `<project>-<env>`. |
+| `aws_s3_artifacts_bucket_override` | Use a different artifacts bucket name instead of `<project>-<env>-artifacts`. |
 | `aws_dynamodb_table_override` | Use an existing table instead of creating one. |
 | `aws_dynamodb_point_in_time_recovery` | Continuous backups on the managed table. Defaults to `true`; incurs [additional cost](https://aws.amazon.com/dynamodb/pricing/). |
 | `ses_receipt_rule_set_name`, `ses_receipt_rule_name` | Manage an existing SES receipt rule. Both required to enable; otherwise SES is left alone. |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Two S3 buckets are created outside Terraform, because one must exist before
 - **An email bucket**, where SES delivers raw messages.
 
 A third bucket, for build artifacts, is created by Terraform, but you have to
-name it through `aws_s3_artifacts_bucket`: bucket names are global, so no
+name it through `aws_s3_artifacts_bucket_override`: bucket names are global, so
 default reliably works. Lambda deployment packages are uploaded there to be
 signed, and its contents are rebuildable from a release.
 
@@ -87,7 +87,7 @@ them as `TF_VAR_` environment variables.
 | Variable | Purpose |
 | --- | --- |
 | `aws_s3_bucket_override` | **Required.** Names the email bucket. There is no default: bucket names are global, so nothing generated from the project name reliably works. |
-| `aws_s3_artifacts_bucket` | **Required.** Names the artifacts bucket Terraform creates for code signing. Global names again, so again no default. |
+| `aws_s3_artifacts_bucket_override` | **Required.** Names the artifacts bucket Terraform creates for code signing. Global names again, so again no default. |
 | `aws_region` | Region to deploy into. Defaults to `us-west-2`. |
 | `project_name`, `environment` | Name resources. Default to `mailbox-v2` and `dev`. |
 | `aws_dynamodb_table_override` | Use an existing table instead of creating one. |
@@ -100,7 +100,7 @@ them as `TF_VAR_` environment variables.
 ```shell
 export TF_STATE_BUCKET=<your-state-bucket>
 export TF_VAR_aws_s3_bucket_override=<your-email-bucket>
-export TF_VAR_aws_s3_artifacts_bucket=<your-artifacts-bucket>
+export TF_VAR_aws_s3_artifacts_bucket_override=<your-artifacts-bucket>
 make init
 make deploy
 ```

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -9,7 +9,7 @@
 # message ID at the root, where versioning would retain every deleted message.
 
 resource "aws_s3_bucket" "artifacts" {
-  bucket = var.aws_s3_artifacts_bucket
+  bucket = local.aws_s3_artifacts_bucket_name
 
   # Rebuildable content, so a leftover object shouldn't wedge terraform destroy
   force_destroy = true

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -117,3 +117,37 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
 
   depends_on = [aws_s3_bucket_versioning.artifacts]
 }
+
+# Uploaded before signing because Signer only reads sources from S3. The
+# depends_on is load-bearing: without versioning on, version_id below is null.
+resource "aws_s3_object" "unsigned" {
+  for_each = local.lambda_packages
+
+  bucket      = aws_s3_bucket.artifacts.id
+  key         = "unsigned/${each.key}.zip"
+  source      = "bin/${each.key}.zip"
+  source_hash = filemd5("bin/${each.key}.zip")
+
+  depends_on = [aws_s3_bucket_versioning.artifacts]
+}
+
+resource "aws_signer_signing_job" "lambda" {
+  for_each = local.lambda_packages
+
+  profile_name = aws_signer_signing_profile.lambda_signing_profile.name
+
+  source {
+    s3 {
+      bucket  = aws_s3_bucket.artifacts.id
+      key     = aws_s3_object.unsigned[each.key].key
+      version = aws_s3_object.unsigned[each.key].version_id
+    }
+  }
+
+  destination {
+    s3 {
+      bucket = aws_s3_bucket.artifacts.id
+      prefix = "signed/${each.key}-"
+    }
+  }
+}

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -9,7 +9,7 @@
 # message ID at the root, where versioning would retain every deleted message.
 
 resource "aws_s3_bucket" "artifacts" {
-  bucket = local.aws_s3_artifacts_bucket_name
+  bucket = var.aws_s3_artifacts_bucket
 
   # Rebuildable content, so a leftover object shouldn't wedge terraform destroy
   force_destroy = true

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -1,14 +1,9 @@
-# Build artifacts for Lambda code signing. AWS Signer only signs S3 objects, so
-# deployment packages are uploaded here, signed in place, and deployed from the
-# signed copy.
-#
-# Terraform owns this bucket, unlike the state and email buckets: nothing has to
-# exist before init, and everything in it is rebuildable from a release. The
-# email bucket can't double as this one - Signer reads its source by version, so
-# the whole bucket has to be versioned, and emails are stored and deleted by
-# message ID at the root, where versioning would retain every deleted message.
+# Build artifacts for Lambda code signing
 
 resource "aws_s3_bucket" "artifacts" {
+  #checkov:skip=CKV_AWS_18: build output already published as a release asset
+  #checkov:skip=CKV_AWS_144: rebuildable from a release
+  #checkov:skip=CKV2_AWS_62: nothing consumes bucket events
   bucket = local.aws_s3_artifacts_bucket_name
 
   # Rebuildable content, so a leftover object shouldn't wedge terraform destroy
@@ -24,9 +19,6 @@ resource "aws_s3_bucket_versioning" "artifacts" {
   }
 }
 
-# SSE-S3, not a CMK: Signer reads the source object on the caller's behalf, and
-# a customer key would need a grant for it in return for control this project
-# doesn't need over artifacts that are public code anyway.
 resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
   bucket = aws_s3_bucket.artifacts.id
 

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -69,10 +69,8 @@ resource "aws_s3_bucket_policy" "artifacts" {
   depends_on = [aws_s3_bucket_public_access_block.artifacts]
 }
 
-# Signed objects are named after the signing job that produced them, so they
-# accumulate instead of overwriting. Lambda copies a package at deploy time and
-# never reads it again, so expiry only costs a re-sign on the way back to an
-# older build.
+# Signed objects are job-named, so they accumulate instead of overwriting.
+# Lambda copies a package at deploy time, so expiry only costs a re-sign.
 resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
   bucket = aws_s3_bucket.artifacts.id
 
@@ -83,7 +81,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
     filter {}
 
     abort_incomplete_multipart_upload {
-      days_after_initiation = 7
+      days_after_initiation = 1
     }
   }
 
@@ -96,7 +94,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
     }
 
     noncurrent_version_expiration {
-      noncurrent_days = 30
+      noncurrent_days = 1
     }
   }
 
@@ -109,10 +107,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
     }
 
     expiration {
-      days = 90
+      days = 1
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
     }
   }
 
-  # Expiring noncurrent versions needs versioning to be on first
   depends_on = [aws_s3_bucket_versioning.artifacts]
 }

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -1,0 +1,126 @@
+# Build artifacts for Lambda code signing. AWS Signer only signs S3 objects, so
+# deployment packages are uploaded here, signed in place, and deployed from the
+# signed copy.
+#
+# Terraform owns this bucket, unlike the state and email buckets: nothing has to
+# exist before init, and everything in it is rebuildable from a release. The
+# email bucket can't double as this one - Signer reads its source by version, so
+# the whole bucket has to be versioned, and emails are stored and deleted by
+# message ID at the root, where versioning would retain every deleted message.
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = local.aws_s3_artifacts_bucket_name
+
+  # Rebuildable content, so a leftover object shouldn't wedge terraform destroy
+  force_destroy = true
+}
+
+# Required by Signer: a signing job names its source object by version
+resource "aws_s3_bucket_versioning" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# SSE-S3, not a CMK: Signer reads the source object on the caller's behalf, and
+# a customer key would need a grant for it in return for control this project
+# doesn't need over artifacts that are public code anyway.
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_policy" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "DenyInsecureTransport"
+      Effect    = "Deny"
+      Principal = "*"
+      Action    = "s3:*"
+      Resource = [
+        aws_s3_bucket.artifacts.arn,
+        "${aws_s3_bucket.artifacts.arn}/*",
+      ]
+      Condition = {
+        Bool = { "aws:SecureTransport" = "false" }
+      }
+    }]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.artifacts]
+}
+
+# Signed objects are named after the signing job that produced them, so they
+# accumulate instead of overwriting. Lambda copies a package at deploy time and
+# never reads it again, so expiry only costs a re-sign on the way back to an
+# older build.
+resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "expire-superseded-unsigned"
+    status = "Enabled"
+
+    filter {
+      prefix = "unsigned/"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "expire-old-signed"
+    status = "Enabled"
+
+    filter {
+      prefix = "signed/"
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
+  # Expiring noncurrent versions needs versioning to be on first
+  depends_on = [aws_s3_bucket_versioning.artifacts]
+}

--- a/main.tf
+++ b/main.tf
@@ -160,15 +160,15 @@ resource "aws_cloudwatch_log_group" "function_logs" {
 }
 
 resource "aws_cloudwatch_log_group" "email_receive_logs" {
-  name              = "/aws/lambda/${local.project_name_env}-email_receive"
+  name              = "/aws/lambda/${local.project_name_env}-${local.email_receive_function}"
   retention_in_days = 365
 }
 
 resource "aws_lambda_function" "email_receive" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  function_name                  = "${local.project_name_env}-email_receive"
-  s3_bucket                      = aws_signer_signing_job.lambda["email_receive"].signed_object[0].s3[0].bucket
-  s3_key                         = aws_signer_signing_job.lambda["email_receive"].signed_object[0].s3[0].key
+  function_name                  = "${local.project_name_env}-${local.email_receive_function}"
+  s3_bucket                      = aws_signer_signing_job.lambda[local.email_receive_function].signed_object[0].s3[0].bucket
+  s3_key                         = aws_signer_signing_job.lambda[local.email_receive_function].signed_object[0].s3[0].key
   handler                        = "bootstrap"
   runtime                        = "provided.al2023"
   role                           = aws_iam_role.lambda_exec_role.arn

--- a/main.tf
+++ b/main.tf
@@ -154,21 +154,21 @@ resource "aws_lambda_code_signing_config" "lambda_code_signing" {
 }
 
 resource "aws_cloudwatch_log_group" "function_logs" {
-  for_each          = tomap(local.lambda_functions)
+  for_each          = tomap(local.lambda_api_functions)
   name              = "/aws/lambda/${local.project_name_env}-${each.key}"
   retention_in_days = 365
 }
 
 resource "aws_cloudwatch_log_group" "email_receive_logs" {
-  name              = "/aws/lambda/${local.project_name_env}-${local.email_receive_function}"
+  name              = "/aws/lambda/${local.project_name_env}-${local.lambda_receive_function}"
   retention_in_days = 365
 }
 
 resource "aws_lambda_function" "email_receive" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  function_name                  = "${local.project_name_env}-${local.email_receive_function}"
-  s3_bucket                      = aws_signer_signing_job.lambda[local.email_receive_function].signed_object[0].s3[0].bucket
-  s3_key                         = aws_signer_signing_job.lambda[local.email_receive_function].signed_object[0].s3[0].key
+  function_name                  = "${local.project_name_env}-${local.lambda_receive_function}"
+  s3_bucket                      = aws_signer_signing_job.lambda[local.lambda_receive_function].signed_object[0].s3[0].bucket
+  s3_key                         = aws_signer_signing_job.lambda[local.lambda_receive_function].signed_object[0].s3[0].key
   handler                        = "bootstrap"
   runtime                        = "provided.al2023"
   role                           = aws_iam_role.lambda_exec_role.arn
@@ -200,7 +200,7 @@ resource "aws_lambda_function" "email_receive" {
 
 resource "aws_lambda_function" "functions" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
-  for_each                       = tomap(local.lambda_functions)
+  for_each                       = tomap(local.lambda_api_functions)
   function_name                  = "${local.project_name_env}-${each.key}"
   s3_bucket                      = aws_signer_signing_job.lambda[each.value.function].signed_object[0].s3[0].bucket
   s3_key                         = aws_signer_signing_job.lambda[each.value.function].signed_object[0].s3[0].key
@@ -234,7 +234,7 @@ resource "aws_lambda_function" "functions" {
 }
 
 resource "aws_apigatewayv2_integration" "integrations" {
-  for_each               = tomap(local.lambda_functions)
+  for_each               = tomap(local.lambda_api_functions)
   api_id                 = aws_apigatewayv2_api.mailbox_api.id
   integration_type       = "AWS_PROXY"
   integration_method     = "POST"
@@ -243,7 +243,7 @@ resource "aws_apigatewayv2_integration" "integrations" {
 }
 
 resource "aws_apigatewayv2_route" "routes" {
-  for_each           = tomap(local.lambda_functions)
+  for_each           = tomap(local.lambda_api_functions)
   api_id             = aws_apigatewayv2_api.mailbox_api.id
   route_key          = "${each.value.httpMethod} ${each.value.httpPath}"
   target             = "integrations/${aws_apigatewayv2_integration.integrations[each.key].id}"
@@ -251,7 +251,7 @@ resource "aws_apigatewayv2_route" "routes" {
 }
 
 resource "aws_lambda_permission" "apigw_invoke" {
-  for_each      = tomap(local.lambda_functions)
+  for_each      = tomap(local.lambda_api_functions)
   statement_id  = "AllowAPIGatewayInvoke-${each.key}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.functions[each.key].function_name

--- a/main.tf
+++ b/main.tf
@@ -147,10 +147,7 @@ resource "aws_lambda_code_signing_config" "lambda_code_signing" {
   }
 
   policies {
-    # TODO: restore "Enforce" once build artifacts are signed with AWS Signer.
-    # Signer only signs S3 objects, so that also means publishing the zips to a
-    # versioned bucket and deploying via s3_bucket/s3_key instead of filename.
-    untrusted_artifact_on_deployment = "Warn"
+    untrusted_artifact_on_deployment = "Enforce"
   }
 
   description = "Code signing configuration for ${local.project_name_env} Lambda functions"
@@ -170,11 +167,11 @@ resource "aws_cloudwatch_log_group" "email_receive_logs" {
 resource "aws_lambda_function" "email_receive" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
   function_name                  = "${local.project_name_env}-email_receive"
-  filename                       = "bin/email_receive.zip"
+  s3_bucket                      = aws_signer_signing_job.lambda["email_receive"].signed_object[0].s3[0].bucket
+  s3_key                         = aws_signer_signing_job.lambda["email_receive"].signed_object[0].s3[0].key
   handler                        = "bootstrap"
   runtime                        = "provided.al2023"
   role                           = aws_iam_role.lambda_exec_role.arn
-  source_code_hash               = filebase64sha256("bin/email_receive.zip")
   reserved_concurrent_executions = 10
   code_signing_config_arn        = aws_lambda_code_signing_config.lambda_code_signing.arn
 
@@ -205,11 +202,11 @@ resource "aws_lambda_function" "functions" {
   #checkov:skip=CKV_AWS_116: TODO: add SQS for DLQ
   for_each                       = tomap(local.lambda_functions)
   function_name                  = "${local.project_name_env}-${each.key}"
-  filename                       = "bin/${each.value.function}.zip"
+  s3_bucket                      = aws_signer_signing_job.lambda[each.value.function].signed_object[0].s3[0].bucket
+  s3_key                         = aws_signer_signing_job.lambda[each.value.function].signed_object[0].s3[0].key
   handler                        = "bootstrap"
   runtime                        = "provided.al2023"
   role                           = aws_iam_role.lambda_exec_role.arn
-  source_code_hash               = filebase64sha256("bin/${each.value.function}.zip")
   reserved_concurrent_executions = 10
   code_signing_config_arn        = aws_lambda_code_signing_config.lambda_code_signing.arn
 

--- a/main.tf
+++ b/main.tf
@@ -92,12 +92,12 @@ resource "aws_iam_policy" "lambda_dynamodb_s3" {
           "s3:GetObject",
           "s3:DeleteObject"
         ]
-        Resource = "arn:aws:s3:::${local.aws_s3_bucket_name}/*"
+        Resource = "arn:aws:s3:::${local.aws_s3_emails_bucket_name}/*"
       },
       {
         Effect   = "Allow"
         Action   = "s3:ListBucket"
-        Resource = "arn:aws:s3:::${local.aws_s3_bucket_name}"
+        Resource = "arn:aws:s3:::${local.aws_s3_emails_bucket_name}"
       },
       {
         Effect = "Allow"
@@ -184,7 +184,7 @@ resource "aws_lambda_function" "email_receive" {
       DYNAMODB_TABLE          = local.aws_dynamodb_table_name
       DYNAMODB_ORIGINAL_INDEX = local.aws_dynamodb_original_index
       DYNAMODB_TIME_INDEX     = local.aws_dynamodb_time_index
-      S3_BUCKET               = local.aws_s3_bucket_name
+      S3_BUCKET               = local.aws_s3_emails_bucket_name
       SQS_QUEUE               = local.aws_sqs_queue_name
       WEBHOOK_URL             = local.webhook_url
     }
@@ -219,7 +219,7 @@ resource "aws_lambda_function" "functions" {
       DYNAMODB_TABLE          = local.aws_dynamodb_table_name
       DYNAMODB_ORIGINAL_INDEX = local.aws_dynamodb_original_index
       DYNAMODB_TIME_INDEX     = local.aws_dynamodb_time_index
-      S3_BUCKET               = local.aws_s3_bucket_name
+      S3_BUCKET               = local.aws_s3_emails_bucket_name
       SQS_QUEUE               = local.aws_sqs_queue_name
       WEBHOOK_URL             = local.webhook_url
     }
@@ -358,7 +358,7 @@ resource "aws_ses_receipt_rule" "receive" {
   tls_policy    = "Optional"
 
   s3_action {
-    bucket_name = local.aws_s3_bucket_name
+    bucket_name = local.aws_s3_emails_bucket_name
     position    = 1
   }
 

--- a/oidc.tf
+++ b/oidc.tf
@@ -61,12 +61,12 @@ resource "aws_iam_policy" "github_plan" {
           # the GetBucket* calls a refresh makes across its sub-resources.
           Effect   = "Allow"
           Action   = ["s3:Get*", "s3:ListBucket"]
-          Resource = "arn:aws:s3:::${var.aws_s3_artifacts_bucket}"
+          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}"
         },
         {
           Effect   = "Allow"
           Action   = ["s3:GetObject", "s3:GetObjectVersion", "s3:GetObjectTagging"]
-          Resource = "arn:aws:s3:::${var.aws_s3_artifacts_bucket}/*"
+          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}/*"
         },
         {
           Effect   = "Allow"

--- a/oidc.tf
+++ b/oidc.tf
@@ -95,6 +95,12 @@ resource "aws_iam_policy" "github_plan" {
           Resource = "arn:aws:signer:${var.aws_region}:${data.aws_caller_identity.current.account_id}:/signing-profiles/*"
         },
         {
+          # no resource-level permissions for this action
+          Effect   = "Allow"
+          Action   = ["signer:DescribeSigningJob"]
+          Resource = "*"
+        },
+        {
           Effect   = "Allow"
           Action   = ["iam:GetRole", "iam:ListRolePolicies", "iam:ListAttachedRolePolicies"]
           Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.project_name_env}-*"

--- a/oidc.tf
+++ b/oidc.tf
@@ -61,12 +61,12 @@ resource "aws_iam_policy" "github_plan" {
           # the GetBucket* calls a refresh makes across its sub-resources.
           Effect   = "Allow"
           Action   = ["s3:Get*", "s3:ListBucket"]
-          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}"
+          Resource = "arn:aws:s3:::${var.aws_s3_artifacts_bucket}"
         },
         {
           Effect   = "Allow"
           Action   = ["s3:GetObject", "s3:GetObjectVersion", "s3:GetObjectTagging"]
-          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}/*"
+          Resource = "arn:aws:s3:::${var.aws_s3_artifacts_bucket}/*"
         },
         {
           Effect   = "Allow"

--- a/oidc.tf
+++ b/oidc.tf
@@ -57,6 +57,18 @@ resource "aws_iam_policy" "github_plan" {
       ] : [],
       [
         {
+          # Read-only and scoped to the one bucket, rather than naming each of
+          # the GetBucket* calls a refresh makes across its sub-resources.
+          Effect   = "Allow"
+          Action   = ["s3:Get*", "s3:ListBucket"]
+          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}"
+        },
+        {
+          Effect   = "Allow"
+          Action   = ["s3:GetObject", "s3:GetObjectVersion", "s3:GetObjectTagging"]
+          Resource = "arn:aws:s3:::${local.aws_s3_artifacts_bucket_name}/*"
+        },
+        {
           Effect   = "Allow"
           Action   = ["apigateway:GET"]
           Resource = "arn:aws:apigateway:${var.aws_region}::/apis/*"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,13 @@ variable "aws_s3_bucket_override" {
   default     = ""
 }
 
+variable "aws_s3_artifacts_bucket_override" {
+  description = "Override for the build artifacts S3 bucket name (optional)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "ses_receipt_rule_set_name" {
   description = "Existing SES receipt rule set to manage a rule in. Leave empty to skip SES entirely."
   type        = string
@@ -68,13 +75,14 @@ variable "tf_state_bucket" {
 }
 
 locals {
-  project_name_env            = "${var.project_name}-${var.environment}"
-  aws_dynamodb_table_name     = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
-  aws_dynamodb_original_index = "OriginalMessageIDIndex"
-  aws_dynamodb_time_index     = "TimeIndex"
-  aws_s3_bucket_name          = var.aws_s3_bucket_override != "" ? var.aws_s3_bucket_override : "${var.project_name}-${var.environment}"
-  aws_sqs_queue_name          = "${var.project_name}-${var.environment}"
-  webhook_url                 = ""
+  project_name_env             = "${var.project_name}-${var.environment}"
+  aws_dynamodb_table_name      = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
+  aws_dynamodb_original_index  = "OriginalMessageIDIndex"
+  aws_dynamodb_time_index      = "TimeIndex"
+  aws_s3_bucket_name           = var.aws_s3_bucket_override != "" ? var.aws_s3_bucket_override : "${var.project_name}-${var.environment}"
+  aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override != "" ? var.aws_s3_artifacts_bucket_override : "${local.project_name_env}-artifacts"
+  aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
+  webhook_url                  = ""
 
   lambda_functions = {
     emails_list = {

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,8 @@ variable "aws_s3_bucket_override" {
   sensitive   = true
 }
 
-variable "aws_s3_artifacts_bucket" {
-  description = "Build artifacts bucket, where packages are signed. Required: bucket names are global, so no default reliably works."
+variable "aws_s3_artifacts_bucket_override" {
+  description = "Build artifacts bucket, where packages are signed. Required for now: bucket names are global, so no default reliably works."
   type        = string
   sensitive   = true
 }
@@ -73,13 +73,14 @@ variable "tf_state_bucket" {
 }
 
 locals {
-  project_name_env            = "${var.project_name}-${var.environment}"
-  aws_dynamodb_table_name     = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
-  aws_dynamodb_original_index = "OriginalMessageIDIndex"
-  aws_dynamodb_time_index     = "TimeIndex"
-  aws_s3_bucket_name          = var.aws_s3_bucket_override
-  aws_sqs_queue_name          = "${var.project_name}-${var.environment}"
-  webhook_url                 = ""
+  project_name_env             = "${var.project_name}-${var.environment}"
+  aws_dynamodb_table_name      = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
+  aws_dynamodb_original_index  = "OriginalMessageIDIndex"
+  aws_dynamodb_time_index      = "TimeIndex"
+  aws_s3_bucket_name           = var.aws_s3_bucket_override
+  aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override
+  aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
+  webhook_url                  = ""
 
   lambda_functions = {
     emails_list = {

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,7 @@ locals {
   aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override
   aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
   webhook_url                  = ""
+  email_receive_function       = "email_receive"
 
   lambda_functions = {
     emails_list = {
@@ -214,6 +215,6 @@ locals {
   # several functions serve more than one route
   lambda_packages = toset(concat(
     [for f in local.lambda_functions : f.function],
-    ["email_receive"],
+    [local.email_receive_function],
   ))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ locals {
   aws_dynamodb_table_name      = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
   aws_dynamodb_original_index  = "OriginalMessageIDIndex"
   aws_dynamodb_time_index      = "TimeIndex"
-  aws_s3_bucket_name           = var.aws_s3_bucket_override
+  aws_s3_emails_bucket_name    = var.aws_s3_bucket_override
   aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override
   aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
   webhook_url                  = ""

--- a/variables.tf
+++ b/variables.tf
@@ -23,11 +23,10 @@ variable "aws_s3_bucket_override" {
   default     = ""
 }
 
-variable "aws_s3_artifacts_bucket_override" {
-  description = "Override for the build artifacts S3 bucket name (optional)"
+variable "aws_s3_artifacts_bucket" {
+  description = "Build artifacts bucket, where packages are signed. Required: bucket names are global, so no default reliably works."
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "ses_receipt_rule_set_name" {
@@ -75,14 +74,13 @@ variable "tf_state_bucket" {
 }
 
 locals {
-  project_name_env             = "${var.project_name}-${var.environment}"
-  aws_dynamodb_table_name      = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
-  aws_dynamodb_original_index  = "OriginalMessageIDIndex"
-  aws_dynamodb_time_index      = "TimeIndex"
-  aws_s3_bucket_name           = var.aws_s3_bucket_override != "" ? var.aws_s3_bucket_override : "${var.project_name}-${var.environment}"
-  aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override != "" ? var.aws_s3_artifacts_bucket_override : "${local.project_name_env}-artifacts"
-  aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
-  webhook_url                  = ""
+  project_name_env            = "${var.project_name}-${var.environment}"
+  aws_dynamodb_table_name     = var.aws_dynamodb_table_override != "" ? var.aws_dynamodb_table_override : "${var.project_name}-${var.environment}"
+  aws_dynamodb_original_index = "OriginalMessageIDIndex"
+  aws_dynamodb_time_index     = "TimeIndex"
+  aws_s3_bucket_name          = var.aws_s3_bucket_override != "" ? var.aws_s3_bucket_override : "${var.project_name}-${var.environment}"
+  aws_sqs_queue_name          = "${var.project_name}-${var.environment}"
+  webhook_url                 = ""
 
   lambda_functions = {
     emails_list = {

--- a/variables.tf
+++ b/variables.tf
@@ -81,9 +81,9 @@ locals {
   aws_s3_artifacts_bucket_name = var.aws_s3_artifacts_bucket_override
   aws_sqs_queue_name           = "${var.project_name}-${var.environment}"
   webhook_url                  = ""
-  email_receive_function       = "email_receive"
+  lambda_receive_function      = "email_receive"
 
-  lambda_functions = {
+  lambda_api_functions = {
     emails_list = {
       function   = "emails_list"
       httpMethod = "GET"
@@ -212,9 +212,9 @@ locals {
     }
   }
 
-  # several functions serve more than one route
+  # unique set of functions, since several functions serve multiple endpoints
   lambda_packages = toset(concat(
-    [for f in local.lambda_functions : f.function],
-    [local.email_receive_function],
+    [for f in local.lambda_api_functions : f.function],
+    [local.lambda_receive_function],
   ))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -210,4 +210,10 @@ locals {
       arnPath    = "/info"
     }
   }
+
+  # several functions serve more than one route
+  lambda_packages = toset(concat(
+    [for f in local.lambda_functions : f.function],
+    ["email_receive"],
+  ))
 }


### PR DESCRIPTION
AWS Signer only signs S3 objects, so deployment packages are now uploaded to a versioned artifacts bucket, signed in place, and deployed from the signed copy instead of a local file.

With every package signed, `untrusted_artifact_on_deployment` goes back to `Enforce`, reverting the workaround from #1176.

Closes #1040
