### PR TITLE
Preview the release deploy in make plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,18 @@ init:
 require-vars:
 	@[ -n "$(TF_VAR_aws_s3_bucket_override)" ] || { echo "TF_VAR_aws_s3_bucket_override is not set"; exit 1; }
 
+# Previews what deploy would do, so it uses the same released binaries.
 .PHONY: plan
-plan: require-vars clean build-lambda
+plan: require-vars download
 	@terraform plan -input=false
 
+# Deploys the binaries built from the working tree rather than the latest release.
 .PHONY: apply
 apply: require-vars clean build-lambda
 	@terraform apply -input=false
 
-# Deploys the binaries from the latest release rather than a local build.
 .PHONY: deploy
-deploy: require-vars clean download
+deploy: require-vars download
 	@terraform apply -input=false
 
 .PHONY: destroy

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ make init
 make deploy
 ```
 
-`make deploy` fetches the Lambda binaries from the latest release. Use
-`make apply` to deploy binaries built from your working tree instead, and
-`make plan` to preview without applying.
+`make deploy` fetches the Lambda binaries from the latest release, and
+`make plan` previews it without applying. Use `make apply` to deploy binaries
+built from your working tree instead.
 
 ### Configure email receiving
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ make init
 make deploy
 ```
 
-`make deploy` fetches the Lambda binaries from the latest release, and
-`make plan` previews it without applying. Use `make apply` to deploy binaries
-built from your working tree instead.
+`make plan` previews what deploying the latest release would change, and
+`make deploy` deploys it. Use `make apply` to deploy binaries built from your
+working tree instead.
 
 ### Configure email receiving
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+set -euo pipefail
+
 ZIP_ONLY=false
-if [ "$1" == "--zip-only" ]; then
+if [ "${1:-}" == "--zip-only" ]; then
   ZIP_ONLY=true
 fi
+
+# bin/ is about to hold local builds, so it no longer holds a release
+rm -f bin/.release
 
 BUILD_COMMIT=$(git rev-parse --short HEAD)
 BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/script/download.sh
+++ b/script/download.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 tag_name=$(
     curl -s https://api.github.com/repos/harryzcy/mailbox/releases/latest |
         grep "tag_name" |
@@ -7,10 +9,23 @@ tag_name=$(
         tr -d "\",[:space:]"
 )
 
+# Records which release bin/ holds, so a re-run downloads nothing when it is
+# already current. Removed by make clean, and absent after a local build.
+stamp="bin/.release"
+
+if [ -f "${stamp}" ] && [ "$(cat "${stamp}")" == "${tag_name}" ]; then
+    echo "bin/ already holds ${tag_name}"
+    exit 0
+fi
+
 url="https://github.com/harryzcy/mailbox/releases/download/${tag_name}/mailbox-linux-amd64.tar.gz"
 
 echo "Downloading build asset from ${url}"
 curl -L "${url}" -o mailbox-linux-amd64.tar.gz
 
-tar -xzvf mailbox-linux-amd64.tar.gz --strip-components=1
+# Replace rather than merge, so a local build left in bin/ can't survive
+rm -rf bin
+tar -xzf mailbox-linux-amd64.tar.gz --strip-components=1
 rm mailbox-linux-amd64.tar.gz
+
+echo "${tag_name}" >"${stamp}"


### PR DESCRIPTION
`make plan` built from the working tree while `make deploy` applied the latest release, so the preview described something other than what would be deployed. Both now use the same released binaries.

`make deploy` also re-downloaded the release on every run, because it wiped `bin/` first. `bin/.release` now records which release is extracted, so a re-run skips the download when it already matches. A local build clears that record, since `bin/` then no longer holds a release.
