### PR TITLE
Support fetching an email without marking it as read

### DIFF
--- a/api/emails/get/main.go
+++ b/api/emails/get/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -36,7 +37,23 @@ func handler(ctx context.Context, req events.APIGatewayV2HTTPRequest) (apiutil.R
 		return apiutil.NewErrorResponse(http.StatusBadRequest, "bad request: invalid messageID"), nil
 	}
 
-	result, err := email.GetAndRead(ctx, dynamodb.NewFromConfig(cfg), messageID)
+	// markRead defaults to true, preload requests set it to false to leave the read state untouched
+	markRead := true
+	if markReadStr := req.QueryStringParameters["markRead"]; markReadStr != "" {
+		markRead, err = strconv.ParseBool(markReadStr)
+		if err != nil {
+			return apiutil.NewErrorResponse(http.StatusBadRequest, "invalid input"), nil
+		}
+	}
+	fmt.Printf("request query: [markRead] %t\n", markRead)
+
+	client := dynamodb.NewFromConfig(cfg)
+	var result *email.GetResult
+	if markRead {
+		result, err = email.GetAndRead(ctx, client, messageID)
+	} else {
+		result, err = email.Get(ctx, client, messageID)
+	}
 	if err != nil {
 		if err == platform.ErrNotFound {
 			fmt.Println("email not found")

--- a/doc/api.md
+++ b/doc/api.md
@@ -58,13 +58,23 @@ Error Response:
 
 ### Get
 
-Get an email given it's messageID.
+Get an email given it's messageID. An unread inbox email is marked as read,
+unless `markRead` is set to false.
 
 `GET /emails/{messageID}`
 
 Path Parameters:
 
 - `messageID`: ID of the email message
+
+Query String Parameters:
+
+- `markRead`: `true` (default) or `false`
+
+Note:
+
+- set `markRead` to false to fetch an email without changing its read state,
+  e.g. when a client preloads emails that the user hasn't opened yet.
 
 Response:
 
@@ -100,6 +110,7 @@ Error Response:
 
 | Status Code | Error Message |
 | ----------- | ------------- |
+| 400 Bad Request | invalid input |
 | 404 Not Found | email not found |
 | 429 Too Many Requests | too many requests |
 

--- a/internal/email/get_test.go
+++ b/internal/email/get_test.go
@@ -156,3 +156,102 @@ func TestGet(t *testing.T) {
 		})
 	}
 }
+
+type mockGetEmailAPI struct {
+	mockGetItem    mockGetItemAPI
+	mockUpdateItem mockUpdateItemAPI
+}
+
+func (m mockGetEmailAPI) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return m.mockGetItem(ctx, params, optFns...)
+}
+
+func (m mockGetEmailAPI) UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return m.mockUpdateItem(ctx, params, optFns...)
+}
+
+func TestGetAndRead(t *testing.T) {
+	env.TableName = "table-for-get-and-read"
+	tests := []struct {
+		item             map[string]dynamodbTypes.AttributeValue
+		expectedUnread   *bool
+		expectMarkedRead bool
+	}{
+		{
+			// unread inbox email is marked as read
+			item: map[string]dynamodbTypes.AttributeValue{
+				"MessageID":     &dynamodbTypes.AttributeValueMemberS{Value: "exampleMessageID"},
+				"TypeYearMonth": &dynamodbTypes.AttributeValueMemberS{Value: "inbox#2022-03"},
+				"DateTime":      &dynamodbTypes.AttributeValueMemberS{Value: "12-01:01:01"},
+				"Unread":        &dynamodbTypes.AttributeValueMemberBOOL{Value: true},
+			},
+			expectedUnread:   aws.Bool(true),
+			expectMarkedRead: true,
+		},
+		{
+			// inbox email that's already read is left alone
+			item: map[string]dynamodbTypes.AttributeValue{
+				"MessageID":     &dynamodbTypes.AttributeValueMemberS{Value: "exampleMessageID"},
+				"TypeYearMonth": &dynamodbTypes.AttributeValueMemberS{Value: "inbox#2022-03"},
+				"DateTime":      &dynamodbTypes.AttributeValueMemberS{Value: "12-01:01:01"},
+			},
+			expectedUnread: aws.Bool(false),
+		},
+		{
+			// draft email has no read state
+			item: map[string]dynamodbTypes.AttributeValue{
+				"MessageID":     &dynamodbTypes.AttributeValueMemberS{Value: "exampleMessageID"},
+				"TypeYearMonth": &dynamodbTypes.AttributeValueMemberS{Value: "draft#2022-03"},
+				"DateTime":      &dynamodbTypes.AttributeValueMemberS{Value: "12-01:01:01"},
+			},
+			expectedUnread: nil,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			markedRead := false
+			client := mockGetEmailAPI{
+				mockGetItem: func(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+					return &dynamodb.GetItemOutput{Item: test.item}, nil
+				},
+				mockUpdateItem: func(_ context.Context, params *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+					markedRead = true
+					assert.Equal(t, "REMOVE Unread", *params.UpdateExpression)
+					return &dynamodb.UpdateItemOutput{}, nil
+				},
+			}
+
+			result, err := GetAndRead(context.TODO(), client, "exampleMessageID")
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedUnread, result.Unread)
+			assert.Equal(t, test.expectMarkedRead, markedRead)
+		})
+	}
+}
+
+// Get, which serves requests that opt out of marking the email as read,
+// only needs the read side of the API and thus can't change the read state.
+func TestGetDoesNotMarkRead(t *testing.T) {
+	env.TableName = "table-for-get-without-read"
+	client := mockGetEmailAPI{
+		mockGetItem: func(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+			return &dynamodb.GetItemOutput{
+				Item: map[string]dynamodbTypes.AttributeValue{
+					"MessageID":     &dynamodbTypes.AttributeValueMemberS{Value: "exampleMessageID"},
+					"TypeYearMonth": &dynamodbTypes.AttributeValueMemberS{Value: "inbox#2022-03"},
+					"DateTime":      &dynamodbTypes.AttributeValueMemberS{Value: "12-01:01:01"},
+					"Unread":        &dynamodbTypes.AttributeValueMemberBOOL{Value: true},
+				},
+			}, nil
+		},
+		mockUpdateItem: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			t.Fatal("read state should not be changed")
+			return nil, nil
+		},
+	}
+
+	result, err := Get(context.TODO(), client, "exampleMessageID")
+	assert.NoError(t, err)
+	assert.Equal(t, aws.Bool(true), result.Unread)
+}


### PR DESCRIPTION
- `GET /emails/{messageID}` always marked an unread inbox email as read, so a client that preloads emails would silently clear their unread state
- Accept a `markRead` query parameter, defaulting to `true`, and take the plain `Get` path when it's `false`